### PR TITLE
Make the creation of new node positions robuster to rounding errors

### DIFF
--- a/riccati/evolve.py
+++ b/riccati/evolve.py
@@ -54,7 +54,7 @@ def osc_evolve(info, x0, x1, h, y0, epsres = 1e-12, epsh = 1e-12):
     if sign*(x0 + h) > sign*x1:
         # Step would be out of bounds, need to rescale and re-eval wn, gn
         h = x1 - x0
-        xscaled = h/2*info.xn + x0 + h/2
+        xscaled = x0 + h/2 * (1 + info.xn)
         info.wn = info.w(xscaled)
         info.gn = info.g(xscaled)
     info.h = h
@@ -136,7 +136,7 @@ def nonosc_evolve(info, x0, x1, h, y0, epsres = 1e-12, epsh = 0.2):
     if sign*(x0 + h) > sign*x1:
         # Step would be out of bounds, need to rescale and re-eval wn, gn
         h = x1 - x0
-        xscaled = h/2*info.xn + x0 + h/2
+        xscaled = x0 + h/2 * (1 + info.xn)
     info.h = h
     # Call nonoscillatory step
     y10, y11, maxerr, s = nonosc_step(info, x0, h, y0[0], y0[1], epsres = epsres)
@@ -328,7 +328,7 @@ def solve(info, xi, xf, yi, dyi, eps = 1e-12, epsh = 1e-12, xeval = np.array([])
                 fdense = np.exp(udense)
                 yeval[positions] = info.a[0]*fdense + info.a[1]*np.conj(fdense)
             else:
-                xscaled = xcurrent + h/2 + h/2*info.nodes[1]
+                xscaled = xcurrent + h/2 * (1 + info.nodes[1])
                 Linterp = interp(xscaled, xdense)
                 yeval[positions] = Linterp @ info.yn
         ys.append(y)
@@ -346,8 +346,8 @@ def solve(info, xi, xf, yi, dyi, eps = 1e-12, epsh = 1e-12, xeval = np.array([])
         else:
             wnext = w(xcurrent + h)
             gnext = g(xcurrent + h)
-            dwnext = 2/h*(Dn @ w(xcurrent + h/2 + h/2*xn))[0]
-            dgnext = 2/h*(Dn @ g(xcurrent + h/2 + h/2*xn))[0]
+            dwnext = 2/h*(Dn @ w(xcurrent + h/2 * (1 + xn)))[0]
+            dgnext = 2/h*(Dn @ g(xcurrent + h/2 * (1 + xn)))[0]
         xcurrent += h
         if intdir*xcurrent < intdir*xf:
             hslo_ini = intdir*min(1e8, np.abs(1/wnext))

--- a/riccati/stepsize.py
+++ b/riccati/stepsize.py
@@ -25,7 +25,7 @@ def choose_nonosc_stepsize(info, x0, h, epsh = 0.2):
     h: float
         Refined stepsize over which 1/w(x) does not change by more than epsh/w(x).
     """
-    xscaled = x0 + h/2 + h/2*info.xp
+    xscaled = x0 + h/2 * (1 + info.xp)
     ws = info.w(xscaled)
     if max(ws) > (1 + epsh)/abs(h):
         return choose_nonosc_stepsize(info, x0, h/2, epsh = epsh)
@@ -71,16 +71,16 @@ def choose_osc_stepsize(info, x0, h, epsh = 1e-12):
         relative error no larger than epsh.
     """
     w, g, L = info.w, info.g, info.L
-    t = x0 + h/2 + h/2*info.xpinterp
-    s = x0 + h/2 + h/2*info.xp
+    t = x0 + h/2 * (1 + info.xpinterp)
+    s = x0 + h/2 * (1 + info.xp)
     if info.p == info.n:
         info.wn = w(s)
         info.gn = g(s)
         ws = info.wn
         gs = info.gn
     else:
-        info.wn = w(x0 + h/2 + h/2*info.xn)
-        info.gn = g(x0 + h/2 + h/2*info.xn)
+        info.wn = w(x0 + h/2 * (1 + info.xn))
+        info.gn = g(x0 + h/2 * (1 + info.xn))
         ws = w(s)
         gs = g(s)
     wana = w(t)


### PR DESCRIPTION
# Description

When passing interpolating functions (e.g. with `interp1d`) for `w(x)` and `g(x)`, these are typically only defined on a domain `[x0, xf]`. Hence, it is important that any nodes that are created later on fall within that domain. 

However, there are many places where new nodes are calculated as
```python
xscaled = x0 + h/2 + h/2 * info.xp
``` 
or similar. When `info.xp` contains a `-1`, then we get `h/2 - h/2`, which for some floats is not exactly zero... That in turn can lead to situations where `xscaled < x0`, which then causes a ValueError in `interp1d`.

This PR turns all instances of `h/2 + h/2 * x` into `h/2 * (1 + x)`, which fixes that issue since `1 - 1` is always exactly zero.


# Checklist:

- [x] I have performed a self-reivew of my own code
- [x] My code contains compliant docstrings
- [x] New and existing unit tests pass locally with my changes
- [ ] I have added tests to prove that my fix is effective or that my feature works
- [ ] I updated the version number
