### PR TITLE
add bremer test example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+build/*
+riccati.egg-info/*
+riccati/__pycache__/*
+riccati/tests/__pycache__/*


### PR DESCRIPTION
# Description

This adds the bremer benchmark as it's own test to the pytest suite. However, the test is failing by a small margin for one value of lambda and is giving a few divide warnings we should look into

```python
                # See Fig 5 from here https://arxiv.org/pdf/2212.06924
                if eps == epss[0]:
                    assert yerr < (eps * lambda_scalar * 140)
                else:
>                   assert yerr < (eps * lambda_scalar * 1e-4)
E                   assert array([2.1229331e-11]) < ((1e-08 * 10.0) * 0.0001)

riccati/tests/test_riccati.py:54: AssertionError
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- Captured stdout call ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-----NEXT-----
lambda_scalar:  10.0
ns:  35
eps:  1e-12
epsh:  1e-13
ytrue:  [0.29131329]
ys[-1]:  (0.29131329343308165+0j)
yerr:  [2.67051142e-11]
-----NEXT-----
lambda_scalar:  10.0
ns:  20
eps:  1e-08
epsh:  1e-09
ytrue:  [0.29131329]
ys[-1]:  (0.2913132934346768+0j)
yerr:  [2.1229331e-11]
=========================================================================================================================================================================================================== warnings summary ============================================================================================================================================================================================================
riccati/tests/test_riccati.py::test_integration
  /home/sbronder/open_source/riccati/riccati/tests/test_riccati.py:67: RuntimeWarning: invalid value encountered in divide
    maxerr = max(np.abs((fs_est - fs)/fs))

riccati/tests/test_riccati.py::test_nonosc_step
riccati/tests/test_riccati.py::test_nonosc_evolve
riccati/tests/test_riccati.py::test_nonosc_evolve_backwards
  /home/sbronder/open_source/riccati/riccati/chebutils.py:289: FutureWarning: `rcond` parameter will change to the default of machine precision times ``max(M, N)`` where M and N are the input matrix dimensions.
  To use the future default and silence this warning we advise to pass `rcond=None`, to keep using the old, explicitly pass `rcond=-1`.
    y1, res, rank, sing = np.linalg.lstsq(D2ic, rhs) # NumPy solve only works for square matrices

riccati/tests/test_riccati.py::test_osc_evolve
riccati/tests/test_riccati.py::test_osc_evolve_backwards
  /home/sbronder/open_source/riccati/riccati/stepsize.py:91: RuntimeWarning: invalid value encountered in divide
    maxgerr = max(np.abs((gest - gana)/gana))

riccati/tests/test_riccati.py::test_osc_evolve
riccati/tests/test_riccati.py::test_osc_evolve_backwards
  /home/sbronder/open_source/riccati/riccati/evolve.py:76: RuntimeWarning: invalid value encountered in scalar divide
    hosc_ini = sign*min(1e8, np.abs(wnext/dwnext), np.abs(gnext/dgnext))

riccati/tests/test_riccati.py::test_nonosc_evolve
riccati/tests/test_riccati.py::test_nonosc_evolve_backwards
  /home/sbronder/open_source/riccati/riccati/stepsize.py:30: RuntimeWarning: divide by zero encountered in scalar divide
    if np.isnan(ws.sum()) == True or max(np.abs(ws)) > (1 + epsh)/abs(h):

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
======================================================================================================================================================================================================== short test summary info ========================================================================================================================================================================================================
FAILED riccati/tests/test_riccati.py::test_bremer - assert array([2.1229331e-11]) < ((1e-08 * 10.0) * 0.0001)
=============================================================================================================================================================================================== 1 failed, 17 passed, 10 warnings in 3.92s 
```

Fixes # (issue)

# Checklist:

- [ ] I have performed a self-reivew of my own code
- [ ] My code contains compliant docstrings
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added tests to prove that my fix is effective or that my feature works
- [ ] I updated the version number
